### PR TITLE
Make integration tests use local charts

### DIFF
--- a/hack/ci/run-integration-tests.sh
+++ b/hack/ci/run-integration-tests.sh
@@ -97,10 +97,6 @@ main() {
     # the addres of the ingress that exposes upload and minio endpoints
     local -r INGRESS_ADDRESS=http://localhost:30080
 
-    junit::test_start "Update_Charts_Dependencies"
-    testHelper::prepare_helm_chart_dependencies "${CHARTS_DIR}" 2>&1 | junit::test_output
-    junit::test_pass
-
     junit::test_start "Install_go_junit_report"
     testHelper::install_go_junit_report 2>&1 | junit::test_output
     junit::test_pass
@@ -136,10 +132,12 @@ main() {
     testHelper::load_images "${CLUSTER_NAME}" "${UPLOADER_IMG_NAME}" "${MANAGER_IMG_NAME}" "${FRONT_MATTER_IMG_NAME}" "${ASYNCAPI_IMG_NAME}" 2>&1 | junit::test_output
     junit::test_pass
 
-
+    junit::test_start "Update_Charts_Dependencies"
+    testHelper::prepare_helm_chart_dependencies "${CHARTS_DIR}" 2>&1 | junit::test_output
+    junit::test_pass
 
     junit::test_start "Install_Rafter"
-    testHelper::install_rafter "${MINIO_ACCESSKEY}" "${MINIO_SECRETKEY}" "${INGRESS_ADDRESS}" 2>&1 | junit::test_output
+    testHelper::install_rafter "${MINIO_ACCESSKEY}" "${MINIO_SECRETKEY}" "${INGRESS_ADDRESS}" "${CHARTS_DIR}" 2>&1 | junit::test_output
     junit::test_pass
 
     junit::test_start "Rafter_Integration_Test"

--- a/hack/ci/run-integration-tests.sh
+++ b/hack/ci/run-integration-tests.sh
@@ -122,7 +122,7 @@ main() {
     junit::test_pass
 
     junit::test_start "Update_Charts_Dependencies"
-    testHelper::prepare_helm_chart_dependencies
+    testHelper::prepare_helm_chart_dependencies  2>&1 | junit::test_output
     junit::test_pass
 
     junit::test_start "Install_Rafter"

--- a/hack/ci/run-integration-tests.sh
+++ b/hack/ci/run-integration-tests.sh
@@ -20,6 +20,8 @@ export PATH="${TMP_BIN_DIR}:${PATH}"
 readonly ARTIFACTS_DIR="${ARTIFACTS:-"${TMP_DIR}/artifacts"}"
 mkdir -p "${ARTIFACTS_DIR}"
 
+readonly CHARTS_DIR="${CURRENT_DIR}/../../charts"
+
 source "${CURRENT_DIR}/envs.sh" || {
     echo 'Cannot load environment variables.'
     exit 1
@@ -47,8 +49,7 @@ function finalize {
 
     log::info "Deleting cluster" 2>&1 | junit::test_output
     kind::delete_cluster "${CLUSTER_NAME}" 2>&1 | junit::test_output || finalization_failed="true"
-    
-    
+
     if [[ ${finalization_failed} = "true" ]]; then
         junit::test_fail || true
     else
@@ -60,8 +61,18 @@ function finalize {
     log::info "Deleting temporary dir ${TMP_DIR}"
     rm -rf "${TMP_DIR}" || true
 
-    log::info "Deleting folder with charts' dependencies"
-    rm -rf "${CURRENT_DIR}/../../charts/rafter/charts"
+    log::info "Deleting files copied to charts directory"
+    log::info "Deleting ${CHARTS_DIR}/rafter/charts/rafter-controller-manager"
+    rm -rf "${CHARTS_DIR}/rafter/charts/rafter-controller-manager" || true
+
+    log::info "Deleting ${CHARTS_DIR}/rafter/charts/rafter-asyncapi-service"
+    rm -rf "${CHARTS_DIR}/rafter/charts/rafter-asyncapi-service" || true
+
+    log::info "Deleting ${CHARTS_DIR}/rafter/charts/rafter-front-matter-service"
+    rm -rf "${CHARTS_DIR}/rafter/charts/rafter-front-matter-service" || true
+
+    log::info "Deleting ${CHARTS_DIR}/rafter/charts/rafter-upload-service"
+    rm -rf "${CHARTS_DIR}/rafter/charts/rafter-upload-service" || true
 
     if [[ ${exit_status} -eq 0 ]]; then
         log::success "Job finished with success"
@@ -122,7 +133,7 @@ main() {
     junit::test_pass
 
     junit::test_start "Update_Charts_Dependencies"
-    testHelper::prepare_helm_chart_dependencies  2>&1 | junit::test_output
+    testHelper::prepare_helm_chart_dependencies "${CHARTS_DIR}" 2>&1 | junit::test_output
     junit::test_pass
 
     junit::test_start "Install_Rafter"

--- a/hack/ci/run-integration-tests.sh
+++ b/hack/ci/run-integration-tests.sh
@@ -60,6 +60,9 @@ function finalize {
     log::info "Deleting temporary dir ${TMP_DIR}"
     rm -rf "${TMP_DIR}" || true
 
+    log::info "Deleting folder with charts' dependencies"
+    rm -rf "${CURRENT_DIR}/../../charts/rafter/charts"
+
     if [[ ${exit_status} -eq 0 ]]; then
         log::success "Job finished with success"
     else
@@ -105,13 +108,9 @@ main() {
     "${STABLE_KUBERNETES_VERSION}" \
     "${CLUSTER_CONFIG}" 2>&1 | junit::test_output
     junit::test_pass
-    
+
     junit::test_start "Install_Tiller"
     testHelper::install_tiller 2>&1 | junit::test_output
-    junit::test_pass
-
-    junit::test_start "Helm_Add_Repo_And_Update"
-    testHelper::add_repos_and_update 2>&1 | junit::test_output
     junit::test_pass
 
     junit::test_start "Install_Ingress"
@@ -120,6 +119,10 @@ main() {
 
     junit::test_start "Load_Images"
     testHelper::load_images "${CLUSTER_NAME}" "${UPLOADER_IMG_NAME}" "${MANAGER_IMG_NAME}" "${FRONT_MATTER_IMG_NAME}" "${ASYNCAPI_IMG_NAME}" 2>&1 | junit::test_output
+    junit::test_pass
+
+    junit::test_start "Update_Charts_Dependencies"
+    testHelper::prepare_helm_chart_dependencies
     junit::test_pass
 
     junit::test_start "Install_Rafter"

--- a/hack/ci/run-integration-tests.sh
+++ b/hack/ci/run-integration-tests.sh
@@ -97,8 +97,12 @@ main() {
     # the addres of the ingress that exposes upload and minio endpoints
     local -r INGRESS_ADDRESS=http://localhost:30080
 
+    junit::test_start "Update_Charts_Dependencies"
+    testHelper::prepare_helm_chart_dependencies "${CHARTS_DIR}" 2>&1 | junit::test_output
+    junit::test_pass
+
     junit::test_start "Install_go_junit_report"
-    testHelper::install_go_junit_report   2>&1 | junit::test_output
+    testHelper::install_go_junit_report 2>&1 | junit::test_output
     junit::test_pass
 
     junit::test_start "Install_Helm_Tiller"
@@ -132,9 +136,7 @@ main() {
     testHelper::load_images "${CLUSTER_NAME}" "${UPLOADER_IMG_NAME}" "${MANAGER_IMG_NAME}" "${FRONT_MATTER_IMG_NAME}" "${ASYNCAPI_IMG_NAME}" 2>&1 | junit::test_output
     junit::test_pass
 
-    junit::test_start "Update_Charts_Dependencies"
-    testHelper::prepare_helm_chart_dependencies "${CHARTS_DIR}" 2>&1 | junit::test_output
-    junit::test_pass
+
 
     junit::test_start "Install_Rafter"
     testHelper::install_rafter "${MINIO_ACCESSKEY}" "${MINIO_SECRETKEY}" "${INGRESS_ADDRESS}" 2>&1 | junit::test_output

--- a/hack/ci/test-helper.sh
+++ b/hack/ci/test-helper.sh
@@ -59,13 +59,14 @@ testHelper::prepare_helm_chart_dependencies(){
 #   $1 - minio access key that will be used during rafter installation
 #   $2 - minio secret key that will be used during the rafter installation
 #   $3 - the addres of the ingress that exposes upload and minio endpoints
+#   $4 - path to charts directory
 testHelper::install_rafter() {
     local -r TAG=latest
     local -r PULL_POLICY=Never
     local -r INSTALL_TIMEOUT=180
     log::info '- Installing rafter from local chart...'
     helm install --name rafter \
-    "${CURRENT_DIR}/../../charts/rafter" \
+    "${4}/rafter" \
     --set rafter-controller-manager.minio.accessKey="${1}" \
     --set rafter-controller-manager.minio.secretKey="${2}" \
     --set rafter-controller-manager.envs.store.externalEndpoint.value="${3}" \

--- a/hack/ci/test-helper.sh
+++ b/hack/ci/test-helper.sh
@@ -43,15 +43,16 @@ testHelper::install_go_junit_report(){
     log::info "- go-junit-reports already installed!"
 }
 
+# Arguments:
+#   $1 - path to charts folder
 testHelper::prepare_helm_chart_dependencies(){
     log::info 'Preparing dependencies for local charts'
-    local -r CHARTS_DIR="${CURRENT_DIR}/../../charts"
-    mkdir "${CHARTS_DIR}/rafter/charts"
-    cp -r "${CHARTS_DIR}/rafter-controller-manager" "${CHARTS_DIR}/rafter/charts"
-    cp -r "${CHARTS_DIR}/rafter-asyncapi-service" "${CHARTS_DIR}/rafter/charts"
-    cp -r "${CHARTS_DIR}/rafter-front-matter-service" "${CHARTS_DIR}/rafter/charts"
-    cp -r "${CHARTS_DIR}/rafter-upload-service" "${CHARTS_DIR}/rafter/charts"
-    helm dependency update "${CHARTS_DIR}/rafter/charts/rafter-controller-manager" # to fetch minio
+    mkdir "${1}/rafter/charts"
+    cp -r "${1}/rafter-controller-manager" "${1}/rafter/charts"
+    cp -r "${1}/rafter-asyncapi-service" "${1}/rafter/charts"
+    cp -r "${1}/rafter-front-matter-service" "${1}/rafter/charts"
+    cp -r "${1}/rafter-upload-service" "${1}/rafter/charts"
+    helm dependency update "${1}/rafter/charts/rafter-controller-manager" # to fetch minio
     log::success "- Updated charts dependencies!"
 }
 # Arguments:

--- a/hack/ci/test-helper.sh
+++ b/hack/ci/test-helper.sh
@@ -47,7 +47,7 @@ testHelper::install_go_junit_report(){
 #   $1 - path to charts folder
 testHelper::prepare_helm_chart_dependencies(){
     log::info 'Preparing dependencies for local charts'
-    mkdir "${1}/rafter/charts"
+    mkdir -p "${1}/rafter/charts"
     cp -r "${1}/rafter-controller-manager" "${1}/rafter/charts"
     cp -r "${1}/rafter-asyncapi-service" "${1}/rafter/charts"
     cp -r "${1}/rafter-front-matter-service" "${1}/rafter/charts"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Make integration tests use local charts instead of those downloaded from https://rafter-charts.storage.googleapis.com/


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #5 