### PR TITLE
Add a tutorial showing the use of ConfigMaps in Rafter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Rafter is a solution for storing and managing different types of files called assets. It uses [MinIO](https://min.io/) as object storage. The whole concept of Rafter relies on [Kubernetes custom resources (CRs)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) managed by the [Rafter Controller Manager](./cmd/manager/README.md). These CRs include:
 
-- Asset CR which manages single assets or asset packages from external URLs or ConfigMaps
+- Asset CR which manages single assets or asset packages from external URLs and ConfigMaps
 - Bucket CR which manages buckets
 - AssetGroup CR which manages a group of Asset CRs of a specific type to make it easier to use and extract webhook information
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Rafter is a solution for storing and managing different types of files called assets. It uses [MinIO](https://min.io/) as object storage. The whole concept of Rafter relies on [Kubernetes custom resources (CRs)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) managed by the [Rafter Controller Manager](./cmd/manager/README.md). These CRs include:
 
-- Asset CR which manages single assets or asset packages from external URLs and ConfigMaps
+- Asset CR which manages single assets or asset packages from URLs or ConfigMaps
 - Bucket CR which manages buckets
 - AssetGroup CR which manages a group of Asset CRs of a specific type to make it easier to use and extract webhook information
 

--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@
 
 Rafter is a solution for storing and managing different types of files called assets. It uses [MinIO](https://min.io/) as object storage. The whole concept of Rafter relies on [Kubernetes custom resources (CRs)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) managed by the [Rafter Controller Manager](./cmd/manager/README.md). These CRs include:
 
-- Asset CR which manages a single asset or a package of assets
+- Asset CR which manages single assets or asset packages from external URLs or ConfigMaps
 - Bucket CR which manages buckets
 - AssetGroup CR which manages a group of Asset CRs of a specific type to make it easier to use and extract webhook information
 
 Rafter enables you to manage assets using supported webhooks. For example, if you use Rafter to store a file such as a specification, you can additionally define a webhook service that Rafter should call before the file is sent to storage. The webhook service can:
 
-- validate the file
-- mutate the file
-- extract some of the file information and put it in the status of the custom resource
+- Validate the file
+- Mutate the file
+- Extract some of the file information and put it in the status of the custom resource
 
 Rafter comes with the following set of services and extensions compatible with Rafter webhooks:
 

--- a/katacoda-tutorials/index.json
+++ b/katacoda-tutorials/index.json
@@ -22,6 +22,10 @@
         "title": "Use Case 3 - Rafter as content storage using advanced webhook services",
         "text": "step4.md"
       }
+      {
+        "title": "Use Case 4 - Rafter as storage for ConfigMaps content",
+        "text": "step5.md"
+      }
     ],
     "intro": {
       "text": "intro.md"

--- a/katacoda-tutorials/index.json
+++ b/katacoda-tutorials/index.json
@@ -21,7 +21,7 @@
       {
         "title": "Use Case 3 - Rafter as content storage using advanced webhook services",
         "text": "step4.md"
-      }
+      },
       {
         "title": "Use Case 4 - Rafter as storage for ConfigMaps content",
         "text": "step5.md"

--- a/katacoda-tutorials/step2.md
+++ b/katacoda-tutorials/step2.md
@@ -1,5 +1,6 @@
-In this scenario, you will learn how to use Rafter to store static webpages. You will create a bucket, push an asset to it, and open the website from sources stored in the bucket. For the purpose of this scenario, the asset is a package containing all static files needed to build a website, such as HTML, JS, and CSS files. Follow these steps:
+In this scenario, you will learn how to use Rafter to store static webpages. You will first create a bucket, then push an asset to it, and finally open the website from sources stored in the bucket. For the purpose of this scenario, the asset is a package containing all static files needed to build a website, such as HTML, JS, and CSS files.
 
+Follow these steps:
 
 1. Export a URL to ready-to-use sources of a simple website as an environment variable:
 
@@ -43,7 +44,7 @@ In this scenario, you will learn how to use Rafter to store static webpages. You
 
    `kubectl get assets webpage -o jsonpath='{.status.phase}'`{{execute}}
 
-5. Export the name of the remote bucket in storage as an environment variable. This name is available in the Bucket CR status and is not exactly the same as the name of a specific Bucket CR:
+5. Export the name of the remote bucket in storage as an environment variable. This name is available in the Bucket CR status and differs from the name of a specific Bucket CR:
 
    `export BUCKET_NAME=$(kubectl get bucket pages -o jsonpath='{.status.remoteName}')`{{execute}}
 

--- a/katacoda-tutorials/step2.md
+++ b/katacoda-tutorials/step2.md
@@ -40,7 +40,7 @@ Follow these steps:
    EOF
    ```{{execute}}
 
-4. Make sure that the status of the Asset CR is `Ready` which means that fetching, unpacking, and filtering was completed. Run:
+4. Make sure that the status of the Asset CR is `Ready` which means that fetching, unpacking, and filtering were completed. Run:
 
    `kubectl get assets webpage -o jsonpath='{.status.phase}'`{{execute}}
 

--- a/katacoda-tutorials/step2.md
+++ b/katacoda-tutorials/step2.md
@@ -1,4 +1,4 @@
-In this scenario, you will learn how to use Rafter to store static webpages. You will first create a bucket, then push an asset to it, and finally open the website from sources stored in the bucket. For the purpose of this scenario, the asset is a package containing all static files needed to build a website, such as HTML, JS, and CSS files.
+In this scenario, you will learn how to use Rafter to store static webpages. You will create a bucket, push an asset to it, and open the website from sources stored in the bucket. For the purpose of this scenario, the asset is a package containing all static files needed to build a website, such as HTML, JS, and CSS files.
 
 Follow these steps:
 
@@ -44,7 +44,7 @@ Follow these steps:
 
    `kubectl get assets webpage -o jsonpath='{.status.phase}'`{{execute}}
 
-5. Export the name of the remote bucket in storage as an environment variable. This name is available in the Bucket CR status and differs from the name of a specific Bucket CR:
+5. Export the name of the remote bucket in storage as an environment variable. This name is available in the Bucket CR status and differs from the name of the Bucket CR:
 
    `export BUCKET_NAME=$(kubectl get bucket pages -o jsonpath='{.status.remoteName}')`{{execute}}
 

--- a/katacoda-tutorials/step2.md
+++ b/katacoda-tutorials/step2.md
@@ -1,4 +1,4 @@
-In this scenario, you will learn how to use Rafter to store static webpages. You will create a bucket, push an asset to it, and open the website from sources stored in the bucket. For the purpose of this scenario, the asset is a package containing all static files needed to build a website, such as HTML, JS, and CSS files.
+In this scenario, you will learn how to use Rafter to store static webpages. You will create a bucket, push an asset to it, and open the website from sources stored in the bucket. For the purpose of this scenario, the asset is a package containing all static files needed to build a website, such as HTML, CSS, and JS files.
 
 Follow these steps:
 

--- a/katacoda-tutorials/step3.md
+++ b/katacoda-tutorials/step3.md
@@ -43,7 +43,7 @@ Follow these steps:
    EOF
    ```{{execute}}
 
-4. Make sure that the status of the Asset CR is `Ready` which means that fetching and communication with the Front Matter Service was completed. Run:
+4. Make sure that the status of the Asset CR is `Ready` which means that fetching and communication with the Front Matter Service were completed. Run:
 
    `kubectl get assets markdown-file -o jsonpath='{.status.phase}'`{{execute}}
 

--- a/katacoda-tutorials/step3.md
+++ b/katacoda-tutorials/step3.md
@@ -8,7 +8,7 @@ Follow these steps:
 
 2. Create a bucket for the Markdown file by applying a Bucket CR. Run:
 
-```yaml
+    ```yaml
      cat <<EOF | kubectl apply -f -
      apiVersion: rafter.kyma-project.io/v1beta1
      kind: Bucket

--- a/katacoda-tutorials/step3.md
+++ b/katacoda-tutorials/step3.md
@@ -1,4 +1,6 @@
-In this scenario, you will create a bucket, push an asset to it, and communicate with a webhook service responsible for extracting metadata from Markdown files. The service will first extract selected metadata from the file specified in the Asset CR and then add it to the Asset CR status. Follow these steps:
+In this scenario, you will create a bucket, push an asset to it, and communicate with a webhook service responsible for extracting metadata from Markdown files. The service will first extract selected metadata from the file specified in the Asset CR and then add it to the Asset CR status.
+
+Follow these steps:
 
 1. Export a URL to a single Markdown file as an environment variable:
 
@@ -6,18 +8,18 @@ In this scenario, you will create a bucket, push an asset to it, and communicate
 
 2. Create a bucket for the Markdown file by applying a Bucket CR. Run:
 
-   ```yaml
-   cat <<EOF | kubectl apply -f -
-   apiVersion: rafter.kyma-project.io/v1beta1
-   kind: Bucket
-   metadata:
-     name: content
-     namespace: default
-   spec:
-     region: "us-east-1"
-     policy: readonly
-   EOF
-   ```{{execute}}
+```yaml
+     cat <<EOF | kubectl apply -f -
+     apiVersion: rafter.kyma-project.io/v1beta1
+     kind: Bucket
+     metadata:
+       name: content
+       namespace: default
+     spec:
+       region: "us-east-1"
+       policy: readonly
+     EOF
+     ```{{execute}}
 
 3. Apply an Asset CR that points to a single Markdown file. To extract metadata from the Markdown file before it goes to storage, specify communication with **metadataWebhookService** in the Asset CR.  As a result, the status of the Asset CR will be enriched with the file metadata. Run:
 
@@ -51,12 +53,12 @@ In this scenario, you will create a bucket, push an asset to it, and communicate
 
 To make sure that the file is in storage and you can extract it, follow these steps:
 
-6. Export the file name and the name of the bucket available in the Bucket CR status as environment variables. The name of the bucket in storage is not exactly the same as the name of a specific Bucket CR:
+6. Export the file name and the name of the remote bucket in storage as environment variables. The name of the remote bucket is available in the Bucket CR status and differs from the name of the Bucket CR:
 
    `export FILE_NAME=$(kubectl get asset markdown-file -o jsonpath='{.status.assetRef.files[0].name}')`{{execute}}
 
    `export BUCKET_NAME=$(kubectl get bucket content -o jsonpath='{.status.remoteName}')`{{execute}}
 
-7. Fetch the file in the terminal window:
+7. Fetch the file content in the terminal window:
 
    `curl https://[[HOST_SUBDOMAIN]]-31311-[[KATACODA_HOST]].environments.katacoda.com/$BUCKET_NAME/markdown-file/$FILE_NAME`{{execute}}

--- a/katacoda-tutorials/step3.md
+++ b/katacoda-tutorials/step3.md
@@ -49,7 +49,7 @@ Follow these steps:
 
 5. Check the status of the Asset CR. Now it has an additional **metadata** object with a set of values. In this scenario, there should be the **title** key with a value.
 
-   `kubectl get asset markdown-file -o jsonpath='{.status.assetRef.files[0].metadata.title}'`{{execute}}
+   `kubectl get assets markdown-file -o jsonpath='{.status.assetRef.files[0].metadata.title}'`{{execute}}
 
 To make sure that the file is in storage and you can extract it, follow these steps:
 

--- a/katacoda-tutorials/step4.md
+++ b/katacoda-tutorials/step4.md
@@ -1,4 +1,6 @@
-In this scenario, you will reuse the `content` bucket created in the previous use case, push an asset to it, and communicate with a webhook service responsible for the validation and conversion of [AsyncAPI](https://asyncapi.org/) specifications. The service will first validate the version of the specification provided in the Asset CR and then convert it to version 2.0. Follow these steps:
+In this scenario, you will reuse the `content` bucket created in the previous use case, push an asset to it, and communicate with a webhook service responsible for the validation and conversion of [AsyncAPI](https://asyncapi.org/) specifications. The service will first validate the version of the specification provided in the Asset CR and then convert it to version 2.0.
+
+Follow these steps:
 
 1. Export a URL to a single AsyncAPI specification file as an environment variable:
 
@@ -36,12 +38,12 @@ In this scenario, you will reuse the `content` bucket created in the previous us
 
 To make sure that the file is in storage and you can extract it, follow these steps:
 
-4. Export the file name and the bucket name as environment variables:
+4. Export the file name and the name of the remote bucket in storage as environment variables. The name of the remote bucket is available in the Bucket CR status and differs from the name of the Bucket CR:
 
    `export FILE_NAME=$(kubectl get asset asyncapi-file -o jsonpath='{.status.assetRef.files[0].name}')`{{execute}}
 
    `export BUCKET_NAME=$(kubectl get bucket content -o jsonpath='{.status.remoteName}')`{{execute}}
 
-5. Fetch the file in the terminal window. It should start with `asyncapi: '2.0.0'`:
+5. Fetch the file content in the terminal window. It should start with `asyncapi: '2.0.0'`:
 
    `curl https://[[HOST_SUBDOMAIN]]-31311-[[KATACODA_HOST]].environments.katacoda.com/$BUCKET_NAME/asyncapi-file/$FILE_NAME`{{execute}}

--- a/katacoda-tutorials/step4.md
+++ b/katacoda-tutorials/step4.md
@@ -32,7 +32,7 @@ Follow these steps:
    EOF
    ```{{execute}}
 
-3. Check if the status of the Asset CR is `Ready` which means that fetching and communication with the AsyncAPI Service was completed. Run:
+3. Check if the status of the Asset CR is `Ready` which means that fetching and communication with the AsyncAPI Service were completed. Run:
 
    `kubectl get assets asyncapi-file -o jsonpath='{.status.phase}'`{{execute}}
 

--- a/katacoda-tutorials/step5.md
+++ b/katacoda-tutorials/step5.md
@@ -71,7 +71,7 @@ Follow these steps:
     EOF
     ```{{execute}}
 
-3. Apply the Asset CR pointing to any asset from the ConfigMap that has the `.md` extension. The **url** parameter specifies the Namespace and ConfigMap names. Run:
+3. Apply the Asset CR that selects from the ConfigMap all assets with the `.md` extension. The **url** parameter specifies the Namespace and ConfigMap names. Run:
 
     ```yaml
     cat <<EOF | kubectl apply -f -

--- a/katacoda-tutorials/step5.md
+++ b/katacoda-tutorials/step5.md
@@ -1,4 +1,4 @@
-This scenario shows how to use ConfigMaps as an alternative asset source in Rafter. You create a ConfigMap with three files, `file1.md`, `file2.js`, and `file3.yaml`. Then will create a Bucket CR and an Asset CR that points to the previously created ConfigMap. By adding filtering to the Asset CR definition, Rafter will only upload the `.md` file from the ConfigMap content and upload it into the bucket.
+This scenario shows how to use ConfigMaps as an alternative asset source in Rafter. You create a ConfigMap with three files, `file1.md`, `file2.js`, and `file3.yaml`. Then it will create a Bucket CR and an Asset CR that points to the previously created ConfigMap. By adding filtering to the Asset CR definition, Rafter will only upload the `.md` file from the ConfigMap content and upload it into the bucket.
 
 Follow these steps:
 

--- a/katacoda-tutorials/step5.md
+++ b/katacoda-tutorials/step5.md
@@ -30,11 +30,11 @@ Follow these steps:
             }).on('end', () => {
                 body = Buffer.concat(body).toString();
 
-          console.log('> Headers');
+                console.log('> Headers');
                 console.log(request.headers);
 
-          console.log('> Body');
-          console.log(body);
+                console.log('> Body');
+                console.log(body);
                 response.end();
             });
         }).listen(8083);
@@ -71,7 +71,7 @@ Follow these steps:
     EOF
     ```{{execute}}
 
-3. Apply the `sample-asset` Asset CR that selects from the ConfigMap all assets with the `.md` extension. The **url** parameter specifies the Namespace and ConfigMap names. Run:
+3. Apply the `sample-asset` Asset CR that selects from the ConfigMap all assets with the `.md` extension. The **url** parameter specifies the Namespace and ConfigMap names and has the `{namespace}/{configMap-name}` format. Run:
 
     ```yaml
     cat <<EOF | kubectl apply -f -

--- a/katacoda-tutorials/step5.md
+++ b/katacoda-tutorials/step5.md
@@ -71,7 +71,7 @@ Follow these steps:
     EOF
     ```{{execute}}
 
-3. Apply the Asset CR pointing to any asset from the ConfigMap that has the `.md` extension. Run:
+3. Apply the Asset CR pointing to any asset from the ConfigMap that has the `.md` extension. The **url** parameter specifies the Namespace and ConfigMap names. Run:
 
     ```yaml
     cat <<EOF | kubectl apply -f -

--- a/katacoda-tutorials/step5.md
+++ b/katacoda-tutorials/step5.md
@@ -1,4 +1,4 @@
-This scenario shows how to use ConfigMaps as an alternative asset source in Rafter. You create a ConfigMap with three files, `file1.md`, `file2.js`, and `file3.yaml`. Then it will create a Bucket CR and an Asset CR that points to the previously created ConfigMap. By adding filtering to the Asset CR definition, Rafter will only upload the `.md` file from the ConfigMap content and upload it into the bucket.
+This scenario shows how to use ConfigMaps as an alternative asset source in Rafter. You will create a ConfigMap with three files, `file1.md`, `file2.js`, and `file3.yaml`. Then you will create a Bucket CR and an Asset CR that points to the previously created ConfigMap. By adding filtering to the Asset CR definition, Rafter will only upload the `.md` file from the ConfigMap content and upload it into the bucket.
 
 Follow these steps:
 

--- a/katacoda-tutorials/step5.md
+++ b/katacoda-tutorials/step5.md
@@ -90,7 +90,7 @@ Follow these steps:
     EOF
     ```{{execute}}
 
-4. Make sure that the status of the Asset CR is `Ready` which means that fetching and filtering was completed. Run:
+4. Make sure that the status of the Asset CR is `Ready` which means that fetching and filtering were completed. Run:
 
    `kubectl get assets sample-asset -o jsonpath='{.status.phase}'`{{execute}}
 

--- a/katacoda-tutorials/step5.md
+++ b/katacoda-tutorials/step5.md
@@ -56,7 +56,7 @@ Follow these steps:
     EOF
     ```{{execute}}
 
-2. Create a bucket by applying the Bucket CR. Run:
+2. Create a bucket by applying the `sample-bucket` Bucket CR. Run:
 
     ```yaml
     cat <<EOF | kubectl apply -f -
@@ -71,7 +71,7 @@ Follow these steps:
     EOF
     ```{{execute}}
 
-3. Apply the Asset CR that selects from the ConfigMap all assets with the `.md` extension. The **url** parameter specifies the Namespace and ConfigMap names. Run:
+3. Apply the `sample-asset` Asset CR that selects from the ConfigMap all assets with the `.md` extension. The **url** parameter specifies the Namespace and ConfigMap names. Run:
 
     ```yaml
     cat <<EOF | kubectl apply -f -

--- a/katacoda-tutorials/step5.md
+++ b/katacoda-tutorials/step5.md
@@ -1,4 +1,4 @@
-This scenario shows how to use ConfigMaps as an alternative asset source in Rafter. You will create a ConfigMap with three files, `file1.md`, `file2.js`, and `file3.yaml`. Then you will create a Bucket CR and an Asset CR that points to the previously created ConfigMap. By adding filtering to the Asset CR definition, Rafter will only upload the `.md` file from the ConfigMap content and upload it into the bucket.
+This scenario shows how to use ConfigMaps as an alternative asset source in Rafter. You will create a ConfigMap with three files, `file1.md`, `file2.js`, and `file3.yaml`. Then you will create a Bucket CR and an Asset CR that points to the previously created ConfigMap. By adding filtering to the Asset CR definition, Rafter will only select the `.md` file from the ConfigMap content and push it into the bucket.
 
 Follow these steps:
 
@@ -13,9 +13,11 @@ Follow these steps:
       namespace: default
     data:
       file1.md: |
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Mattis rhoncus urna neque viverra justo nec ultrices dui. Venenatis cras sed felis eget velit. Aliquam nulla facilisi cras fermentum odio. Nec ultrices dui sapien eget mi. Auctor elit sed vulputate mi sit amet mauris commodo quis. In pellentesque massa placerat duis ultricies lacus sed. Gravida arcu ac tortor dignissim convallis aenean et. Quisque sagittis purus sit amet. Nibh sit amet commodo nulla facilisi nullam vehicula ipsum. Rhoncus aenean vel elit scelerisque mauris pellentesque pulvinar pellentesque habitant. Auctor elit sed vulputate mi sit. Sed adipiscing diam donec adipiscing tristique risus. Nunc non blandit massa enim. Felis donec et odio pellentesque diam.
+        Rafter is a solution for storing and managing different types of files called assets. It uses MinIO as object storage. The whole concept of Rafter relies on Kubernetes custom resources (CRs) managed by the Rafter Controller Manager. These CRs include:
 
-        Auctor elit sed vulputate mi sit amet mauris. Amet consectetur adipiscing elit duis tristique. Tellus rutrum tellus pellentesque eu. Nam libero justo laoreet sit amet cursus sit. Sagittis aliquam malesuada bibendum arcu vitae elementum. Amet tellus cras adipiscing enim eu turpis. Auctor urna nunc id cursus metus aliquam eleifend mi. Nec sagittis aliquam malesuada bibendum arcu vitae elementum curabitur. Consectetur lorem donec massa sapien faucibus et molestie ac. Sed risus pretium quam vulputate dignissim suspendisse in. Felis eget nunc lobortis mattis aliquam faucibus.
+          - Asset CR which manages single assets or asset packages from URLs or ConfigMaps
+          - Bucket CR which manages buckets
+          - AssetGroup CR which manages a group of Asset CRs of a specific type to make it easier to use and extract webhook information
 
       file2.js: |
         const http = require('http');
@@ -69,7 +71,7 @@ Follow these steps:
     EOF
     ```{{execute}}
 
-3. Apply the Asset CR pointing to assets from the ConfigMap that have the `.md` extension. Run:
+3. Apply the Asset CR pointing to any asset from the ConfigMap that has the `.md` extension. Run:
 
     ```yaml
     cat <<EOF | kubectl apply -f -

--- a/katacoda-tutorials/step5.md
+++ b/katacoda-tutorials/step5.md
@@ -1,0 +1,103 @@
+This scenario shows how to use ConfigMaps as an alternative asset source in Rafter. You create a ConfigMap with three files, `file1.md`, `file2.js`, and `file3.yaml`. Then will create a Bucket CR and an Asset CR that points to the previously created ConfigMap. By adding filtering to the Asset CR definition, Rafter will only upload the `.md` file from the ConfigMap content and upload it into the bucket.
+
+Follow these steps:
+
+1. Create the `sample-configmap` ConfigMap that contains sources of files with three different extensions:
+
+    ```yaml
+    cat <<EOF | kubectl apply -f -
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: sample-configmap
+      namespace: default
+    data:
+      file1.md: |
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Mattis rhoncus urna neque viverra justo nec ultrices dui. Venenatis cras sed felis eget velit. Aliquam nulla facilisi cras fermentum odio. Nec ultrices dui sapien eget mi. Auctor elit sed vulputate mi sit amet mauris commodo quis. In pellentesque massa placerat duis ultricies lacus sed. Gravida arcu ac tortor dignissim convallis aenean et. Quisque sagittis purus sit amet. Nibh sit amet commodo nulla facilisi nullam vehicula ipsum. Rhoncus aenean vel elit scelerisque mauris pellentesque pulvinar pellentesque habitant. Auctor elit sed vulputate mi sit. Sed adipiscing diam donec adipiscing tristique risus. Nunc non blandit massa enim. Felis donec et odio pellentesque diam.
+
+        Auctor elit sed vulputate mi sit amet mauris. Amet consectetur adipiscing elit duis tristique. Tellus rutrum tellus pellentesque eu. Nam libero justo laoreet sit amet cursus sit. Sagittis aliquam malesuada bibendum arcu vitae elementum. Amet tellus cras adipiscing enim eu turpis. Auctor urna nunc id cursus metus aliquam eleifend mi. Nec sagittis aliquam malesuada bibendum arcu vitae elementum curabitur. Consectetur lorem donec massa sapien faucibus et molestie ac. Sed risus pretium quam vulputate dignissim suspendisse in. Felis eget nunc lobortis mattis aliquam faucibus.
+
+      file2.js: |
+        const http = require('http');
+        const server = http.createServer();
+
+        server.on('request', (request, response) => {
+            let body = [];
+            request.on('data', (chunk) => {
+                body.push(chunk);
+            }).on('end', () => {
+                body = Buffer.concat(body).toString();
+
+          console.log('> Headers');
+                console.log(request.headers);
+
+          console.log('> Body');
+          console.log(body);
+                response.end();
+            });
+        }).listen(8083);
+
+      file3.yaml: |
+        apiVersion: apiextensions.k8s.io/v1beta1
+        kind: CustomResourceDefinition
+        metadata:
+          annotations:
+            controller-gen.kubebuilder.io/version: v0.2.4
+          creationTimestamp: null
+          name: assetgroups.rafter.kyma-project.io
+        spec:
+          additionalPrinterColumns:
+          - JSONPath: .status.phase
+            name: Phase
+            type: string
+          - JSONPath: .metadata.creationTimestamp
+    EOF
+    ```{{execute}}
+
+2. Create a bucket by applying the Bucket CR. Run:
+
+    ```yaml
+    cat <<EOF | kubectl apply -f -
+    apiVersion: rafter.kyma-project.io/v1beta1
+    kind: Bucket
+    metadata:
+      name: sample-bucket
+      namespace: default
+    spec:
+      region: "us-east-1"
+      policy: readonly
+    EOF
+    ```{{execute}}
+
+3. Apply the Asset CR pointing to assets from the ConfigMap that have the `.md` extension. Run:
+
+    ```yaml
+    cat <<EOF | kubectl apply -f -
+    apiVersion: rafter.kyma-project.io/v1beta1
+    kind: Asset
+    metadata:
+      name: sample-asset
+      namespace: default
+    spec:
+      source:
+        url: default/sample-configmap
+        mode: configmap
+        filter: \.md$
+      bucketRef:
+        name: sample-bucket
+    EOF
+    ```{{execute}}
+
+4. Make sure that the status of the Asset CR is `Ready` which means that fetching and filtering was completed. Run:
+
+   `kubectl get assets sample-asset -o jsonpath='{.status.phase}'`{{execute}}
+
+To make sure that the file is in storage and you can extract it, follow these steps:
+
+1. Export the name of the remote bucket in storage as an environment variable. The name of the remote bucket is available in the Bucket CR status and differs from the name of the Bucket CR:
+
+   `export BUCKET_NAME=$(kubectl get bucket sample-bucket -o jsonpath='{.status.remoteName}')`{{execute}}
+
+2. Fetch the file content in the terminal window:
+
+  `curl https://[[HOST_SUBDOMAIN]]-31311-[[KATACODA_HOST]].environments.katacoda.com/$BUCKET_NAME/sample-asset/file1.md`{{execute}}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Added a new tutorial that shows how you can use ConfigMaps as content sources for Assets
- Added info to the main README.md on available asset sources (including ConfigMaps)

**Related issue(s)**
See also #61 
