### PR TITLE
Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of the `rafter` repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @aerfio @magicmatatjahu @michal-hudy @m00g3n @pPrecel
+* @aerfio @magicmatatjahu @m00g3n @pPrecel
 
 # All .md files
 *.md @kazydek @mmitoraj @bszwarc @klaudiagrz

--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,4 @@
 approvers:
-  - michal-hudy
   - m00g3n
   - aerfio
   - magicmatatjahu

--- a/charts/rafter-asyncapi-service/Chart.yaml
+++ b/charts/rafter-asyncapi-service/Chart.yaml
@@ -18,8 +18,6 @@ keywords:
 maintainers:
   - name: derberg
     email: "lukasz.gornicki.83@gmail.com"
-  - name: michal-hudy
-    email: "michal@hudy.pl"
   - name: m00g3n
     email: "marcin.witalis@gmail.com"
   - name: aerfio
@@ -28,4 +26,3 @@ maintainers:
     email: "filip.strozik@outlook.com"
   - name: magicmatatjahu
     email: "urbanczyk.maciej.95@gmail.com"
-

--- a/charts/rafter-controller-manager/Chart.yaml
+++ b/charts/rafter-controller-manager/Chart.yaml
@@ -17,8 +17,6 @@ keywords:
 maintainers:
   - name: derberg
     email: "lukasz.gornicki.83@gmail.com"
-  - name: michal-hudy
-    email: "michal@hudy.pl"
   - name: m00g3n
     email: "marcin.witalis@gmail.com"
   - name: aerfio
@@ -27,4 +25,3 @@ maintainers:
     email: "filip.strozik@outlook.com"
   - name: magicmatatjahu
     email: "urbanczyk.maciej.95@gmail.com"
-

--- a/charts/rafter-front-matter-service/Chart.yaml
+++ b/charts/rafter-front-matter-service/Chart.yaml
@@ -18,8 +18,6 @@ keywords:
 maintainers:
   - name: derberg
     email: "lukasz.gornicki.83@gmail.com"
-  - name: michal-hudy
-    email: "michal@hudy.pl"
   - name: m00g3n
     email: "marcin.witalis@gmail.com"
   - name: aerfio

--- a/charts/rafter-upload-service/Chart.yaml
+++ b/charts/rafter-upload-service/Chart.yaml
@@ -18,8 +18,6 @@ keywords:
 maintainers:
   - name: derberg
     email: "lukasz.gornicki.83@gmail.com"
-  - name: michal-hudy
-    email: "michal@hudy.pl"
   - name: m00g3n
     email: "marcin.witalis@gmail.com"
   - name: aerfio

--- a/charts/rafter/Chart.yaml
+++ b/charts/rafter/Chart.yaml
@@ -21,8 +21,6 @@ keywords:
 maintainers:
   - name: derberg
     email: "lukasz.gornicki.83@gmail.com"
-  - name: michal-hudy
-    email: "michal@hudy.pl"
   - name: m00g3n
     email: "marcin.witalis@gmail.com"
   - name: aerfio


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

In recent months, Paweł Kosiec, Adam Szecówka, Tomek Papiernik and Michał Hudy left the company. According to the [offboarding guidelines](https://kyma-project.io/community/governance#kyma-working-model-kyma-working-model-when-does-a-maintainer-lose-the-maintainer-status), a person should be removed from codeowners in case they are no longer interested in contributing or haven't contributed to the project for more than 3 months. As for the persons mentioned above, the following reasons occurred:

- After consulting Paweł and Tomek, I've learned that they are no longer interested in contributing to the project.
- Adam has been inactive for more than 3 months.
- Michał has changed his GitHub login and thus the old one should be removed from all the codeowners files. His new login is already mentioned in the [emeritus file](https://github.com/kyma-project/community/blob/master/emeritus.md).

Changes proposed in this pull request:

- Remove `pkosiec` from codeowners
- Remove `aszecowka` from codeowners
- Remove `tomekpapiernik` from codeowners
- Remove `michal-hudy` from codeowners

**Related issue(s)**
[#50](https://github.tools.sap/kyma/community/issues/50)