### PR TITLE
Change podAnnotations.persistence from false to off

### DIFF
--- a/charts/rafter-controller-manager/values.yaml
+++ b/charts/rafter-controller-manager/values.yaml
@@ -7,8 +7,13 @@ fullnameOverride:
 
 minio:
   enabled: true
+  persistence:
+    enabled: true
+    size: 10Gi
   accessKey: ""
   secretKey: ""
+  podAnnotations:
+    persistence: "on"
 
 image:
   repository: eu.gcr.io/kyma-project/rafter-controller-manager

--- a/charts/rafter-upload-service/README.md
+++ b/charts/rafter-upload-service/README.md
@@ -156,9 +156,6 @@ envs:
 
 ### Switch MinIO to Gateway mode
 
-By default, you install the Upload Service with MinIO in stand-alone mode. If you want to switch MinIO to Gateway mode and you don't want to lose your buckets uploaded by the Upload Service, you must first override parameters for MinIO under the **minio** object and change these parameters to `false`: 
-
-- **minio.persistence.enabled**
-- **minio.podAnnotations.persistence**
+By default, you install the Upload Service with MinIO in stand-alone mode. If you want to switch MinIO to Gateway mode and you don't want to lose your buckets uploaded by the Upload Service, you must first override parameters for MinIO under the **minio** object and change **minio.persistence.enabled** parameter to `false` and **minio.podAnnotations.persistence** to `off`.
 
 > **NOTE:** If the names of deployments or secrets used before and after switching to Gateway mode differ, you must update parameters under **migrator.pre** and **migrator.post** objects.

--- a/charts/rafter-upload-service/templates/_helper_migrate_buckets.txt
+++ b/charts/rafter-upload-service/templates/_helper_migrate_buckets.txt
@@ -66,15 +66,15 @@ copyFromBucket() {
 }
 
 isPersistence() {
-  if grep -q "true" "/export/persistence.enabled"; then
-    return 0
+  if grep -q "off" "/export/persistence.enabled"; then
+    return 1
   fi
 
-  return 1
+  return 0
 }
 
 if ! isPersistence; then
-  echo "Persistence is not enabled, skipping..."
+  echo "Persistence from previous release is not enabled, skipping..."
   exit 0
 fi
 

--- a/charts/rafter-upload-service/values.yaml
+++ b/charts/rafter-upload-service/values.yaml
@@ -13,7 +13,7 @@ minio:
   accessKey: ""
   secretKey: ""
   podAnnotations:
-    persistence: "true"
+    persistence: "on"
 
 image:
   repository: eu.gcr.io/kyma-project/rafter-upload-service

--- a/charts/rafter/README.md
+++ b/charts/rafter/README.md
@@ -105,8 +105,11 @@ rafter-controller-manager:
 By default, you install the Upload Service with MinIO in stand-alone mode. If you want to switch MinIO to Gateway mode and you don't want to lose your buckets uploaded by the Upload Service, you must override parameters for MinIO under the **rafter-controller-manager.minio** object and change these parameters to `false`:
 
 - **rafter-upload-service.minio.persistence.enabled**
-- **rafter-upload-service.minio.podAnnotations.persistence**
 - **rafter-controller-manager.minio.persistence.enabled**
+
+and these parameters to `off`:
+
+- **rafter-upload-service.minio.podAnnotations.persistence**
 - **rafter-controller-manager.minio.podAnnotations.persistence**
 
 > **NOTE:** If the names of deployments or secrets used before and after switching to Gateway mode differ, you must update parameters under **rafter-upload-service.migrator.pre** and **rafter-upload-service.migrator.post** objects.

--- a/charts/rafter/values.yaml
+++ b/charts/rafter/values.yaml
@@ -143,13 +143,14 @@ rafter-controller-manager:
       size: 10Gi
 
     podAnnotations:
-      persistence: "true"
+      persistence: "on"
 
     DeploymentUpdate:
       type: Recreate
 
     environment:
       MINIO_BROWSER: "off"
+      MINIO_PROMETHEUS_AUTH_TYPE: "public"
 
     defaultBucket:
       enabled: false
@@ -171,7 +172,7 @@ rafter-upload-service:
       enabled: true
       size: 10Gi
     podAnnotations:
-      persistence: "true"
+      persistence: "on"
 
   image:
     repository: eu.gcr.io/kyma-project/rafter-upload-service

--- a/hack/ci/lib/minio/azure-gateway.sh
+++ b/hack/ci/lib/minio/azure-gateway.sh
@@ -173,7 +173,7 @@ gateway::switch() {
   helm upgrade "${release_name}" "${charts_path}" \
     --reuse-values \
     --set rafter-controller-manager.minio.persistence.enabled="false" \
-    --set rafter-controller-manager.minio.podAnnotations.persistence="\"false\"" \
+    --set rafter-controller-manager.minio.podAnnotations.persistence="off" \
     --set rafter-controller-manager.minio.existingSecret="${MINIO_GATEWAY_SECRET_NAME}" \
     --set rafter-controller-manager.minio.azuregateway.enabled="true" \
     --set rafter-controller-manager.minio.DeploymentUpdate.type="RollingUpdate" \
@@ -182,7 +182,7 @@ gateway::switch() {
     --set rafter-controller-manager.envs.store.accessKey.valueFrom.secretKeyRef.name="${MINIO_GATEWAY_SECRET_NAME}" \
     --set rafter-controller-manager.envs.store.secretKey.valueFrom.secretKeyRef.name="${MINIO_GATEWAY_SECRET_NAME}" \
     --set rafter-upload-service.minio.persistence.enabled="false" \
-    --set rafter-upload-service.minio.podAnnotations.persistence="\"false\"" \
+    --set rafter-upload-service.minio.podAnnotations.persistence="off" \
     --set rafter-upload-service.envs.upload.accessKey.valueFrom.secretKeyRef.name="${MINIO_GATEWAY_SECRET_NAME}" \
     --set rafter-upload-service.envs.upload.secretKey.valueFrom.secretKeyRef.name="${MINIO_GATEWAY_SECRET_NAME}" \
     --set rafter-upload-service.migrator.post.minioSecretRefName="${MINIO_GATEWAY_SECRET_NAME}" \

--- a/hack/ci/lib/minio/gcs-gateway.sh
+++ b/hack/ci/lib/minio/gcs-gateway.sh
@@ -146,7 +146,7 @@ gateway::switch() {
   helm upgrade "${release_name}" "${charts_path}" \
     --reuse-values \
     --set rafter-controller-manager.minio.persistence.enabled="false" \
-    --set rafter-controller-manager.minio.podAnnotations.persistence="\"false\"" \
+    --set rafter-controller-manager.minio.podAnnotations.persistence="off" \
     --set rafter-controller-manager.minio.existingSecret="${MINIO_GATEWAY_SECRET_NAME}" \
     --set rafter-controller-manager.minio.gcsgateway.enabled="true" \
     --set rafter-controller-manager.minio.gcsgateway.projectId="${CLOUDSDK_CORE_PROJECT}" \
@@ -156,7 +156,7 @@ gateway::switch() {
     --set rafter-controller-manager.envs.store.accessKey.valueFrom.secretKeyRef.name="${MINIO_GATEWAY_SECRET_NAME}" \
     --set rafter-controller-manager.envs.store.secretKey.valueFrom.secretKeyRef.name="${MINIO_GATEWAY_SECRET_NAME}" \
     --set rafter-upload-service.minio.persistence.enabled="false" \
-    --set rafter-upload-service.minio.podAnnotations.persistence="\"false\"" \
+    --set rafter-upload-service.minio.podAnnotations.persistence="off" \
     --set rafter-upload-service.envs.upload.accessKey.valueFrom.secretKeyRef.name="${MINIO_GATEWAY_SECRET_NAME}" \
     --set rafter-upload-service.envs.upload.secretKey.valueFrom.secretKeyRef.name="${MINIO_GATEWAY_SECRET_NAME}" \
     --set rafter-upload-service.migrator.post.minioSecretRefName="${MINIO_GATEWAY_SECRET_NAME}" \


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

As in title: change `podAnnotations.persistence` values from `false` to `off` -> `true` and `false` as string is not very good for Helm and also for Kyma installator. Kyma installator converts `false`|`true` (write as string) to boolean and in Helm we must add extra quotes -> it also converts values.

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/9335