### PR TITLE
Update rafter charts link

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Try out [this](https://katacoda.com/rafter/) set of interactive tutorials to see
 
 1. Add a new chart's repository to Helm. Run:
 
-   `helm repo add rafter-charts https://rafter-charts.storage.googleapis.com`
+   `helm repo add rafter-charts https://kyma-project.github.io/rafter`
 
 2. Install Rafter:
 

--- a/charts/rafter-asyncapi-service/README.md
+++ b/charts/rafter-asyncapi-service/README.md
@@ -9,7 +9,7 @@ This project contains the Helm chart for the AsyncAPI Service.
 - The `rafter-charts` repository added to your Helm client with this command:
 
 ```bash
-helm repo add rafter-charts https://rafter-charts.storage.googleapis.com
+helm repo add rafter-charts https://kyma-project.github.io/rafter
 ```
 
 ## Details

--- a/charts/rafter-controller-manager/README.md
+++ b/charts/rafter-controller-manager/README.md
@@ -9,7 +9,7 @@ This project contains the Helm chart for the Rafter Controller Manager.
 - The `rafter-charts` repository added to your Helm client with this command:
 
 ```bash
-helm repo add rafter-charts https://rafter-charts.storage.googleapis.com
+helm repo add rafter-charts https://kyma-project.github.io/rafter
 ```
 
 ## Details

--- a/charts/rafter-front-matter-service/README.md
+++ b/charts/rafter-front-matter-service/README.md
@@ -9,7 +9,7 @@ This project contains the Helm chart for the Front Matter Service.
 - The `rafter-charts` repository added to your Helm client with this command:
 
 ```bash
-helm repo add rafter-charts https://rafter-charts.storage.googleapis.com
+helm repo add rafter-charts https://kyma-project.github.io/rafter
 ```
 
 ## Details

--- a/charts/rafter-upload-service/README.md
+++ b/charts/rafter-upload-service/README.md
@@ -9,7 +9,7 @@ This project contains the Helm chart for the Upload Service.
 - The `rafter-charts` repository added to your Helm client with this command:
 
 ```bash
-helm repo add rafter-charts https://rafter-charts.storage.googleapis.com
+helm repo add rafter-charts https://kyma-project.github.io/rafter
 ```
 
 ## Details

--- a/charts/rafter/README.md
+++ b/charts/rafter/README.md
@@ -14,7 +14,7 @@ This project contains the main Helm chart for Rafter. It includes:
 - The `rafter-charts` repository added to your Helm client with this command:
 
 ```bash
-helm repo add rafter-charts https://rafter-charts.storage.googleapis.com
+helm repo add rafter-charts https://kyma-project.github.io/rafter
 ```
 
 ## Details

--- a/charts/rafter/requirements.lock
+++ b/charts/rafter/requirements.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: rafter-controller-manager
-  repository: https://rafter-charts.storage.googleapis.com/
+  repository: https://kyma-project.github.io/rafter/
   version: 0.1.0
 - name: rafter-upload-service
-  repository: https://rafter-charts.storage.googleapis.com/
+  repository: https://kyma-project.github.io/rafter/
   version: 0.1.0
 - name: rafter-front-matter-service
-  repository: https://rafter-charts.storage.googleapis.com/
+  repository: https://kyma-project.github.io/rafter/
   version: 0.1.0
 - name: rafter-asyncapi-service
-  repository: https://rafter-charts.storage.googleapis.com/
+  repository: https://kyma-project.github.io/rafter/
   version: 0.1.0
 digest: sha256:24d4c8f469a38dda2210cac846f73cff892ec7602e7763fd0891b82b6ad65683
 generated: "2019-11-27T14:34:03.292676+01:00"

--- a/charts/rafter/requirements.yaml
+++ b/charts/rafter/requirements.yaml
@@ -1,17 +1,17 @@
 dependencies:
-- name: rafter-controller-manager
-  version: 0.1.*
-  repository: https://rafter-charts.storage.googleapis.com/
-  condition: rafter-controller-manager.enabled
-- name: rafter-upload-service
-  version: 0.1.*
-  repository: https://rafter-charts.storage.googleapis.com/
-  condition: rafter-upload-service.enabled
-- name: rafter-front-matter-service
-  version: 0.1.*
-  repository: https://rafter-charts.storage.googleapis.com/
-  condition: rafter-front-matter-service.enabled
-- name: rafter-asyncapi-service
-  version: 0.1.*
-  repository: https://rafter-charts.storage.googleapis.com/
-  condition: rafter-asyncapi-service.enabled
+  - name: rafter-controller-manager
+    version: 0.1.*
+    repository: https://kyma-project.github.io/rafter/
+    condition: rafter-controller-manager.enabled
+  - name: rafter-upload-service
+    version: 0.1.*
+    repository: https://kyma-project.github.io/rafter/
+    condition: rafter-upload-service.enabled
+  - name: rafter-front-matter-service
+    version: 0.1.*
+    repository: https://kyma-project.github.io/rafter/
+    condition: rafter-front-matter-service.enabled
+  - name: rafter-asyncapi-service
+    version: 0.1.*
+    repository: https://kyma-project.github.io/rafter/
+    condition: rafter-asyncapi-service.enabled

--- a/charts/rafter/requirements.yaml
+++ b/charts/rafter/requirements.yaml
@@ -1,17 +1,17 @@
 dependencies:
-  - name: rafter-controller-manager
-    version: 0.1.*
-    repository: https://kyma-project.github.io/rafter/
-    condition: rafter-controller-manager.enabled
-  - name: rafter-upload-service
-    version: 0.1.*
-    repository: https://kyma-project.github.io/rafter/
-    condition: rafter-upload-service.enabled
-  - name: rafter-front-matter-service
-    version: 0.1.*
-    repository: https://kyma-project.github.io/rafter/
-    condition: rafter-front-matter-service.enabled
-  - name: rafter-asyncapi-service
-    version: 0.1.*
-    repository: https://kyma-project.github.io/rafter/
-    condition: rafter-asyncapi-service.enabled
+- name: rafter-controller-manager
+  version: 0.1.*
+  repository: https://kyma-project.github.io/rafter/
+  condition: rafter-controller-manager.enabled
+- name: rafter-upload-service
+  version: 0.1.*
+  repository: https://kyma-project.github.io/rafter/
+  condition: rafter-upload-service.enabled
+- name: rafter-front-matter-service
+  version: 0.1.*
+  repository: https://kyma-project.github.io/rafter/
+  condition: rafter-front-matter-service.enabled
+- name: rafter-asyncapi-service
+  version: 0.1.*
+  repository: https://kyma-project.github.io/rafter/
+  condition: rafter-asyncapi-service.enabled

--- a/katacoda-tutorials/step1.md
+++ b/katacoda-tutorials/step1.md
@@ -2,7 +2,7 @@ Before you follow the steps, wait for the environment setup to finish. Once read
 
 1. Add a new chart's repository to Helm. Run:
 
-   `helm repo add rafter-charts https://rafter-charts.storage.googleapis.com`{{execute}}
+   `helm repo add rafter-charts https://kyma-project.github.io/rafter`{{execute}}
 
 2. Install Rafter:
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Updated links to rafter charts (now hosted via [github pages](https://kyma-project.github.io/rafter)).
