### PR TITLE
Remove @bszwarc from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,7 +8,7 @@
 * @aerfio @magicmatatjahu @m00g3n @pPrecel
 
 # All .md files
-*.md @kazydek @mmitoraj @bszwarc @klaudiagrz
+*.md @kazydek @mmitoraj @klaudiagrz
 
 # The documentation directory
-/docs/ @kazydek @mmitoraj @bszwarc @klaudiagrz
+/docs/ @kazydek @mmitoraj @klaudiagrz


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Basia left Kyma in September and has not continued contributing to our project since then. According to the [offboarding guidelines](https://kyma-project.io/community/governance#kyma-working-model-kyma-working-model-when-does-a-maintainer-lose-the-maintainer-status), a person should be removed from codeowners in case they are no longer interested in contributing or haven't contributed to the project for more than 3 months. 

Changes proposed in this pull request:

- Remove @bszwarc from CODEOWNERS
